### PR TITLE
Config call

### DIFF
--- a/MediaNetAdSDK/build.gradle
+++ b/MediaNetAdSDK/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -44,4 +45,9 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 
     implementation project(':analytics')
+    //moshi parsing
+    implementation 'com.squareup.moshi:moshi-kotlin-codegen:1.9.3'
+    kapt("com.squareup.moshi:moshi-kotlin-codegen:1.14.0")
+
+    implementation project(path: ':network')
 }

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/Ad.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/Ad.kt
@@ -91,7 +91,7 @@ abstract class Ad {
                         Log.e("Nikhil", "error in adjusting ad view")
                     }
                 })
-                AnalyticsSDK.pushEvent(Event(name = "ad_loaded", type = LoggingEvents.SLOT_OPPORTUNITY.type))
+                AnalyticsSDK.pushEvent(Event(name = "ad_loaded", type = LoggingEvents.OPPORTUNITY.type))
                 listener.onAdLoaded()
             }
 

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/Ad.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/Ad.kt
@@ -9,6 +9,8 @@ import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.admanager.AdManagerAdView
+import com.medianet.android.adsdk.utils.Constants
+import com.medianet.android.adsdk.utils.Util
 import org.prebid.mobile.AdUnit
 import org.prebid.mobile.PrebidMobile
 import org.prebid.mobile.ResultCode

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/Constants.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/Constants.kt
@@ -1,7 +1,0 @@
-package com.medianet.android.adsdk
-
-import org.prebid.mobile.ResultCode
-
-object Constants {
-    const val KEY_AD_RENDERED: String = "ad_rendered"
-}

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/LoggingEvents.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/LoggingEvents.kt
@@ -1,5 +1,5 @@
 package com.medianet.android.adsdk
 
 enum class LoggingEvents(val type: String) {
-    PROJECT("PE"), SLOT_OPPORTUNITY("SOE")
+    PROJECT("PE"), OPPORTUNITY("OE")
 }

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/MediaNetAdSDK.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/MediaNetAdSDK.kt
@@ -95,10 +95,11 @@ object MediaNetAdSDK {
                 projectEventPercentage = it.logPercentage.projectEvent.toInt(),
                 opportunityEventPercentage = it.logPercentage.opportunityEvent.toInt(),
                 shouldKillSDK = it.publisherConfig.killSwitch,
-                auctionUrl = it.urls.auctionLayerUrl,
+                bidRequestUrl = it.urls.auctionLayerUrl,
                 projectEventUrl = it.urls.projectEventUrl,
                 opportunityEventUrl = it.urls.opportunityEventUrl,
-                dpfToCrIdMap = crIdMap
+                dpfToCrIdMap = crIdMap,
+                dummyCCrId = data.dummyCrId.crId
             )
         }
         return null
@@ -106,7 +107,7 @@ object MediaNetAdSDK {
 
     private suspend fun updateSDKConfigDependencies(applicationContext: Context, config: Configuration) {
         PrebidMobile.setPrebidServerAccountId(config.accountId)
-        PrebidMobile.setPrebidServerHost(Host.createCustomHost(config.auctionUrl)) //PrebidMobile.setPrebidServerHost(Host.createCustomHost(HOST_URL))
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost(config.bidRequestUrl)) //PrebidMobile.setPrebidServerHost(Host.createCustomHost(HOST_URL))
         PrebidMobile.setTimeoutMillis(config.auctionTimeOutMillis.toInt())
         //Initialising Analytics
         initAnalytics(applicationContext, config)
@@ -222,11 +223,12 @@ object MediaNetAdSDK {
         val accountId: String,
         val auctionTimeOutMillis: Long,
         val dpfToCrIdMap: MutableMap<String, String>,
+        val dummyCCrId: String,
         val eventsBufferInterval: Long = 0,
         val projectEventPercentage: Int,
         val opportunityEventPercentage: Int,
         val shouldKillSDK: Boolean,
-        val auctionUrl: String,
+        val bidRequestUrl: String,
         val projectEventUrl: String,
         val opportunityEventUrl: String
     )

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/MediaNetAdSDK.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/MediaNetAdSDK.kt
@@ -7,7 +7,15 @@ import com.app.analytics.SamplingMap
 import com.app.analytics.providers.AnalyticsProviderFactory
 import com.app.network.RetryPolicy
 import com.app.network.wrapper.safeApiCall
+import com.medianet.android.adsdk.utils.Constants.KEY_CC
+import com.medianet.android.adsdk.utils.Constants.KEY_DN
+import com.medianet.android.adsdk.utils.Constants.KEY_UGD
+import com.medianet.android.adsdk.utils.Constants.VALUE_MOBILE
+import com.medianet.android.adsdk.utils.Constants.VALUE_US
 import com.medianet.android.adsdk.model.ConfigResponse
+import com.medianet.android.adsdk.network.NetworkComponentFactory
+import com.medianet.android.adsdk.network.ServerApiService
+import com.medianet.android.adsdk.utils.Util
 import kotlinx.coroutines.*
 import org.prebid.mobile.Host
 import org.prebid.mobile.LogUtil
@@ -106,9 +114,9 @@ object MediaNetAdSDK {
 
     private suspend fun getConfigFromServer(accountId: String): ConfigResponse? {
         val configParams = mapOf(
-            "cc" to "US",
-            "dn" to BuildConfig.LIBRARY_PACKAGE_NAME,
-            "ugd" to "mobile"
+            KEY_CC to VALUE_US,
+            KEY_DN to BuildConfig.LIBRARY_PACKAGE_NAME,
+            KEY_UGD to VALUE_MOBILE
         )
         val configResult = safeApiCall(
             apiCall = {
@@ -187,7 +195,7 @@ object MediaNetAdSDK {
             .build()
 
         //TODO we get interval minute from config, need to update code for this use case, currently we only sync immediately
-        val analyticsProvider = AnalyticsProviderFactory.getCachedProvider(applicationContext, "", 0)
+        val analyticsProvider = AnalyticsProviderFactory.getCachedProvider(applicationContext, sdkConfig.projectEventUrl, 0)
         AnalyticsSDK.init(applicationContext, configuration, providers = listOf(analyticsProvider))
     }
 

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/MediaNetAdSDK.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/MediaNetAdSDK.kt
@@ -4,7 +4,11 @@ import android.content.Context
 import android.util.Log
 import com.app.analytics.AnalyticsSDK
 import com.app.analytics.SamplingMap
-import com.app.analytics.events.Event
+import com.app.analytics.providers.AnalyticsProviderFactory
+import com.app.network.RetryPolicy
+import com.app.network.wrapper.safeApiCall
+import com.medianet.android.adsdk.model.ConfigResponse
+import kotlinx.coroutines.*
 import org.prebid.mobile.Host
 import org.prebid.mobile.LogUtil
 import org.prebid.mobile.PrebidMobile
@@ -17,14 +21,16 @@ object MediaNetAdSDK {
     const val TAG = "MediaNetAdSDK"
     const val TEMP_ACCOUNT_ID = "0689a263-318d-448b-a3d4-b02e8a709d9d" //TODO - should store in preference ?
     private const val HOST_URL = "https://prebid-server-test-j.prebid.org/openrtb2/auction" //TODO - should store in preference ?
+    private const val CONFIG_BASE_URL = "http://ems-adserving-stage-1.traefik.internal.media.net/" //TODO - should store in preference ?
+    private const val CID = "8CU15Y85L" // Temp account Id for config call
+    private var sdkOnVacation: Boolean = false
+    val coroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     private var logLevel: MLogLevel = MLogLevel.INFO
     // TODO - For some action we can check if test mode is on or not
     private var isTestMode: Boolean = false
 
-
     private var publisherSdkInitListener: MSdkInitListener? = null
-
     private var prebidSdkInitializationListener: SdkInitializationListener = object : SdkInitializationListener  {
         override fun onSdkInit() {
             Log.d(TAG, "SDK initialized successfully!")
@@ -41,22 +47,84 @@ object MediaNetAdSDK {
         }
 
     }
+    private var serverApiService: ServerApiService? = NetworkComponentFactory.getServerApiService(CONFIG_BASE_URL)
+    private var config: Configuration? = null
 
     fun initPrebidSDK(
         applicationContext : Context,
         accountId: String,
         sdkInitListener: MSdkInitListener? = null
     ) {
-        LogUtil.setBaseTag(TAG)
-        PrebidMobile.setPrebidServerAccountId(accountId)
-        PrebidMobile.setPrebidServerHost(Host.createCustomHost(HOST_URL))
-        publisherSdkInitListener = sdkInitListener
-        PrebidMobile.initializeSdk(applicationContext, prebidSdkInitializationListener)
-        TargetingParams.setSubjectToGDPR(true)
+        coroutineScope.launch {
+            LogUtil.setBaseTag(TAG)
+            val configFromServer = getConfigFromServer(CID) //TODO - replace it with account ID provided by publisher
+            config = getSDKConfig(configFromServer)
 
+            //Disable SDK if kill switch is onn
+            if (config == null || config?.shouldKillSDK == true) {
+                sdkOnVacation = true
+                return@launch
+            }
+            config?.let {
+                updateSDKConfigDependencies(applicationContext, it)
+            }
+            publisherSdkInitListener = sdkInitListener
+            PrebidMobile.initializeSdk(applicationContext, prebidSdkInitializationListener)
+            //TODO - that need to be come from customer
+            TargetingParams.setSubjectToGDPR(true)
+        }
+    }
 
-        //Initialising Aanalytics
-        initAnalytics(applicationContext)
+    private fun getSDKConfig(data: ConfigResponse?): MediaNetAdSDK.Configuration? {
+        data?.let {
+            val crIdMap = mutableMapOf<String, String>()
+            it.crIds.map { item ->
+                crIdMap.put(item.dfpAdUnitId, item.crId)
+            }
+            return Configuration(
+                accountId = data.pub.cId,
+                auctionTimeOutMillis = it.timeout.auctionTimeout.toLong(),
+                projectEventPercentage = it.logPercentage.projectEvent.toInt(),
+                opportunityEventPercentage = it.logPercentage.opportunityEvent.toInt(),
+                shouldKillSDK = it.publisherConfig.killSwitch,
+                auctionUrl = it.urls.auctionLayerUrl,
+                projectEventUrl = it.urls.projectEventUrl,
+                opportunityEventUrl = it.urls.opportunityEventUrl,
+                dpfToCrIdMap = crIdMap
+            )
+        }
+        return null
+    }
+
+    private suspend fun updateSDKConfigDependencies(applicationContext: Context, config: Configuration) {
+        PrebidMobile.setPrebidServerAccountId(config.accountId)
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost(config.auctionUrl)) //PrebidMobile.setPrebidServerHost(Host.createCustomHost(HOST_URL))
+        PrebidMobile.setTimeoutMillis(config.auctionTimeOutMillis.toInt())
+        //Initialising Analytics
+        initAnalytics(applicationContext, config)
+    }
+
+    private suspend fun getConfigFromServer(accountId: String): ConfigResponse? {
+        val configParams = mapOf(
+            "cc" to "US",
+            "dn" to BuildConfig.LIBRARY_PACKAGE_NAME,
+            "ugd" to "mobile"
+        )
+        val configResult = safeApiCall(
+            apiCall = {
+                serverApiService?.getSdkConfig(accountId, configParams)
+            },
+            successTransform = {
+                it
+            },
+            retryPolicy = RetryPolicy(maxTries = 0)
+        )
+        return if (configResult.isSuccess) {
+            configResult.successValue()
+        } else {
+            Log.e(TAG, "config call fails: ${configResult.errorValue()?.errorModel?.errorMessage}")
+            null
+        }
     }
 
     // TODO - publisherAccountId is better name?
@@ -71,7 +139,6 @@ object MediaNetAdSDK {
     //TODO - should expose PrebidMobile.setCustomHeaders()
 
     //TODO - should expose PrebidMobile.getApplicationContext()
-
     fun enableTestMode() = apply {
         isTestMode = true
         PrebidMobile.setPbsDebug(true)
@@ -107,25 +174,44 @@ object MediaNetAdSDK {
 
     fun setSubjectToGDPR(enable: Boolean) = apply { TargetingParams.setSubjectToGDPR(enable) }
 
-    private fun initAnalytics(applicationContext: Context) {
+    private fun initAnalytics(applicationContext: Context, sdkConfig: Configuration) {
+        //TODO pass config to our AnalyticsEventFactory also
+
         val samplingMap = SamplingMap()
-        samplingMap.put(LoggingEvents.PROJECT.type, 100) //TODO get this in config call
-        samplingMap.put(LoggingEvents.SLOT_OPPORTUNITY.type, 100) //TODO get this in config call
+        samplingMap.put(LoggingEvents.PROJECT.type, sdkConfig.projectEventPercentage)
+        samplingMap.put(LoggingEvents.OPPORTUNITY.type, sdkConfig.opportunityEventPercentage)
 
         val configuration = AnalyticsSDK.Configuration.Builder()
-            .setDebugMode(false)
-            .setAnalyticsUrl("https://logstash-gcpi.net") //TODO get this in config call
-            .enableEventCaching(true)
+            .setAnalyticsUrl("") // There are multiple type of events with different base url so setting base url for SDK as empty, we will send url in event itself
             .enableEventSampling(false, samplingMap)
             .build()
 
-        AnalyticsSDK.init(applicationContext, configuration)
-        //AnalyticsSDK.pushEvent(Event(name = "Config_call_success", type = LoggingEvents.PROJECT.type))
+        //TODO we get interval minute from config, need to update code for this use case, currently we only sync immediately
+        val analyticsProvider = AnalyticsProviderFactory.getCachedProvider(applicationContext, "", 0)
+        AnalyticsSDK.init(applicationContext, configuration, providers = listOf(analyticsProvider))
     }
 
+    // This method is being used by every Ad class before any functioning
+    fun isSdkOnVacation() = sdkOnVacation
 
     //TODO - when to call this
     fun clear() {
         AnalyticsSDK.clear()
+        coroutineScope.coroutineContext.cancelChildren()
+        config = null
+        serverApiService = null
     }
+
+    data class Configuration(
+        val accountId: String,
+        val auctionTimeOutMillis: Long,
+        val dpfToCrIdMap: MutableMap<String, String>,
+        val eventsBufferInterval: Long = 0,
+        val projectEventPercentage: Int,
+        val opportunityEventPercentage: Int,
+        val shouldKillSDK: Boolean,
+        val auctionUrl: String,
+        val projectEventUrl: String,
+        val opportunityEventUrl: String
+    )
 }

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/NetworkComponentFactory.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/NetworkComponentFactory.kt
@@ -1,0 +1,25 @@
+package com.medianet.android.adsdk
+
+import com.app.network.builder.RetrofitBuilder
+import com.app.network.builder.RetrofitParams
+import okhttp3.logging.HttpLoggingInterceptor
+
+object NetworkComponentFactory {
+    private lateinit var serverApiService: ServerApiService
+
+    private val retrofitParams: RetrofitParams = RetrofitParams().apply {
+        apiInterceptors = mutableListOf(HttpLoggingInterceptor().apply { setLevel(HttpLoggingInterceptor.Level.BODY) })
+        retryOnConnectionFailure = true
+    }
+
+    fun getServerApiService(baseUrl: String, networkConfig: RetrofitParams? = null): ServerApiService  {
+        if (this::serverApiService.isInitialized.not()) {
+            serverApiService = RetrofitBuilder(
+                baseUrl = baseUrl,
+                apiInterface = ServerApiService::class.java,
+                retrofitParams = networkConfig ?: retrofitParams
+            ).create()
+        }
+        return serverApiService
+    }
+}

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/ServerApiService.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/ServerApiService.kt
@@ -1,0 +1,11 @@
+package com.medianet.android.adsdk
+
+import com.medianet.android.adsdk.model.ConfigResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.QueryMap
+
+interface ServerApiService {
+    @GET("/adserving/sdk/v1/adservingview/supply/{cid}")
+    suspend fun getSdkConfig(@Path("cid") cid: String, @QueryMap queryMap: Map<String, String>): ConfigResponse
+}

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/model/ConfigResponse.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/model/ConfigResponse.kt
@@ -1,0 +1,94 @@
+package com.medianet.android.adsdk.model
+
+import androidx.annotation.Keep
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class ConfigResponse(
+    @Json(name = "crids")
+    val crIds: List<Crid>,
+    @Json(name = "glb_cfg")
+    val globalConfig: GlobalConfig,
+    @Json(name = "log")
+    val logPercentage: LoggingPercentage,
+    @Json(name = "pub")
+    val pub: PublisherIds,
+    @Json(name = "pub_cfg")
+    val publisherConfig: PublisherConfig,
+    @Json(name = "tgt")
+    val targeting: Targeting,
+    @Json(name = "to")
+    val timeout: TimeOut,
+    @Json(name = "urls")
+    val urls: Urls
+)
+
+@JsonClass(generateAdapter = true)
+data class Crid(
+    @Json(name = "div")
+    val dfpAdUnitId: String,
+    @Json(name = "id")
+    val crId: String,
+    @Json(name = "nm")
+    val name: String
+)
+
+@JsonClass(generateAdapter = true)
+data class GlobalConfig(
+    @Json(name = "buff_sync_sec")
+    val bufferSyncSeconds: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class LoggingPercentage(
+    @Json(name = "opp_event")
+    val opportunityEvent: Double,
+    @Json(name = "pro_event")
+    val projectEvent: Double
+)
+
+@JsonClass(generateAdapter = true)
+data class PublisherIds(
+    @Json(name = "cid")
+    val cId: String,
+    @Json(name = "pid")
+    val publisherId: String
+)
+
+@JsonClass(generateAdapter = true)
+data class PublisherConfig(
+    @Json(name = "df")
+    val defaultFlag: Boolean,
+    @Json(name = "ks")
+    val killSwitch: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class Targeting(
+    @Json(name = "cc")
+    val countryCode: String,
+    @Json(name = "dn")
+    val domainName: String,
+    @Json(name = "ugd")
+    val ugd: String,
+    @Json(name = "v")
+    val version: String
+)
+
+@JsonClass(generateAdapter = true)
+data class TimeOut(
+    @Json(name = "auc_to")
+    val auctionTimeout: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class Urls(
+    @Json(name = "auc_layer")
+    val auctionLayerUrl: String,
+    @Json(name = "opp_event")
+    val opportunityEventUrl: String,
+    @Json(name = "pro_event")
+    val projectEventUrl: String
+)

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/model/ConfigResponse.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/model/ConfigResponse.kt
@@ -22,7 +22,9 @@ data class ConfigResponse(
     @Json(name = "to")
     val timeout: TimeOut,
     @Json(name = "urls")
-    val urls: Urls
+    val urls: Urls,
+    @Json(name = "dummy_crid")
+    val dummyCrId: Crid
 )
 
 @JsonClass(generateAdapter = true)

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/network/ApiConstants.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/network/ApiConstants.kt
@@ -1,0 +1,5 @@
+package com.medianet.android.adsdk.network
+
+object ApiConstants {
+    const val CONFIG_CALL_ENDPOINT = "/adserving/sdk/v1/adservingview/supply/{cid}"
+}

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/network/NetworkComponentFactory.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/network/NetworkComponentFactory.kt
@@ -1,4 +1,4 @@
-package com.medianet.android.adsdk
+package com.medianet.android.adsdk.network
 
 import com.app.network.builder.RetrofitBuilder
 import com.app.network.builder.RetrofitParams
@@ -12,7 +12,7 @@ object NetworkComponentFactory {
         retryOnConnectionFailure = true
     }
 
-    fun getServerApiService(baseUrl: String, networkConfig: RetrofitParams? = null): ServerApiService  {
+    fun getServerApiService(baseUrl: String, networkConfig: RetrofitParams? = null): ServerApiService {
         if (this::serverApiService.isInitialized.not()) {
             serverApiService = RetrofitBuilder(
                 baseUrl = baseUrl,

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/network/ServerApiService.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/network/ServerApiService.kt
@@ -1,11 +1,12 @@
-package com.medianet.android.adsdk
+package com.medianet.android.adsdk.network
 
 import com.medianet.android.adsdk.model.ConfigResponse
+import com.medianet.android.adsdk.network.ApiConstants.CONFIG_CALL_ENDPOINT
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.QueryMap
 
 interface ServerApiService {
-    @GET("/adserving/sdk/v1/adservingview/supply/{cid}")
+    @GET(CONFIG_CALL_ENDPOINT)
     suspend fun getSdkConfig(@Path("cid") cid: String, @QueryMap queryMap: Map<String, String>): ConfigResponse
 }

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/rendering/banner/BannerAd.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/rendering/banner/BannerAd.kt
@@ -3,8 +3,8 @@ package com.medianet.android.adsdk.rendering.banner
 import android.content.Context
 import android.widget.FrameLayout
 import com.google.android.gms.ads.AdSize
-import com.medianet.android.adsdk.Util
-import com.medianet.android.adsdk.Util.getPrebidAdSizeFromGAMAdSize
+import com.medianet.android.adsdk.utils.Util
+import com.medianet.android.adsdk.utils.Util.getPrebidAdSizeFromGAMAdSize
 import com.medianet.android.adsdk.rendering.AdEventListener
 import org.prebid.mobile.api.exceptions.AdException
 import org.prebid.mobile.api.rendering.BannerView

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/rendering/interstitial/InterstitialAd.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/rendering/interstitial/InterstitialAd.kt
@@ -3,8 +3,8 @@ package com.medianet.android.adsdk.rendering.interstitial
 import android.app.Activity
 import android.content.Context
 import com.medianet.android.adsdk.AdType
-import com.medianet.android.adsdk.Util.mapAdExceptionToError
-import com.medianet.android.adsdk.Util.mapInterstitialAdFormat
+import com.medianet.android.adsdk.utils.Util.mapAdExceptionToError
+import com.medianet.android.adsdk.utils.Util.mapInterstitialAdFormat
 import com.medianet.android.adsdk.rendering.AdEventListener
 import org.prebid.mobile.AdSize
 import org.prebid.mobile.api.exceptions.AdException

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/utils/Constants.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/utils/Constants.kt
@@ -1,0 +1,14 @@
+package com.medianet.android.adsdk.utils
+
+import org.prebid.mobile.ResultCode
+
+object Constants {
+    const val KEY_AD_RENDERED: String = "ad_rendered"
+
+    //temp
+    const val KEY_CC = "cc"
+    const val KEY_DN = "dn"
+    const val KEY_UGD = "ugd"
+    const val VALUE_US = "US"
+    const val VALUE_MOBILE = "mobile"
+}

--- a/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/utils/Util.kt
+++ b/MediaNetAdSDK/src/main/java/com/medianet/android/adsdk/utils/Util.kt
@@ -1,7 +1,8 @@
-package com.medianet.android.adsdk
+package com.medianet.android.adsdk.utils
 
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.LoadAdError
+import com.medianet.android.adsdk.*
 import org.prebid.mobile.ContentObject
 import org.prebid.mobile.ContentObject.ProducerObject
 import org.prebid.mobile.DataObject

--- a/analytics/src/main/java/com/app/analytics/events/Event.kt
+++ b/analytics/src/main/java/com/app/analytics/events/Event.kt
@@ -3,6 +3,7 @@ package com.app.analytics.events
 data class Event(
      val name: String,
      val timeStamp: Long = System.currentTimeMillis(),
+     val baseUrl: String = "",
      val params: Map<String, String> = mutableMapOf(),
      val type: String
 )

--- a/analytics/src/main/java/com/app/analytics/providers/AnalyticsProvider.kt
+++ b/analytics/src/main/java/com/app/analytics/providers/AnalyticsProvider.kt
@@ -1,12 +1,15 @@
 package com.app.analytics.providers
 
 import com.app.analytics.events.Event
+import com.app.analytics.providers.defaults.DefaultAnalyticsPixel
 
 interface AnalyticsProvider {
     val defaultParams: MutableMap<String, Any>
     fun getName(): String
     suspend fun pushEvent(event: Event): Boolean
     suspend fun pushEvents(events: List<Event>): Boolean
+    suspend fun pushPixel(pixel: DefaultAnalyticsPixel): Boolean
+    suspend fun pushPixels(pixels: List<DefaultAnalyticsPixel>): Boolean
     fun setDefaultParams(params: Map<String, Any>)
     fun clean()
 }

--- a/analytics/src/main/java/com/app/analytics/providers/AnalyticsProviderFactory.kt
+++ b/analytics/src/main/java/com/app/analytics/providers/AnalyticsProviderFactory.kt
@@ -42,10 +42,15 @@ object AnalyticsProviderFactory {
     }
 
     fun addCachedAnalytics(applicationContext: Context, baseUrl: String, syncIntervalInMinutes: Long) {
+        val provider = getCachedProvider(applicationContext, baseUrl, syncIntervalInMinutes)
+        providers.add(provider)
+    }
+
+    fun getCachedProvider(applicationContext: Context, baseUrl: String, syncIntervalInMinutes: Long): CachedAnalyticsProvider {
         val pushService = NetworkComponentFactory.getPushToServerService(baseUrl)
         val eventDbRepo = DbComponentFactory.getEventDbRepository(applicationContext)
-        val defaultProvider = CachedAnalyticsProvider(applicationContext, baseUrl, eventDbRepo, pushService, syncIntervalInMinutes)
-        providers.add(defaultProvider)
+        val provider = CachedAnalyticsProvider(applicationContext, baseUrl, eventDbRepo, pushService, syncIntervalInMinutes)
+        return provider
     }
 
     fun addDebugAnalytics() {

--- a/analytics/src/main/java/com/app/analytics/providers/debug/DebugAnalyticsProvider.kt
+++ b/analytics/src/main/java/com/app/analytics/providers/debug/DebugAnalyticsProvider.kt
@@ -2,6 +2,7 @@ package com.app.analytics.providers.debug
 
 import com.app.analytics.events.Event
 import com.app.analytics.providers.AnalyticsProvider
+import com.app.analytics.providers.defaults.DefaultAnalyticsPixel
 import com.app.analytics.utils.Constant
 import com.app.logger.CustomLogger
 
@@ -26,6 +27,18 @@ class DebugAnalyticsProvider : AnalyticsProvider {
     override suspend fun pushEvents(events: List<Event>): Boolean {
         events.forEach {
             pushEvent(it)
+        }
+        return true
+    }
+
+    override suspend fun pushPixel(pixel: DefaultAnalyticsPixel): Boolean {
+        CustomLogger.debug(TAG, "Sending pixel: $pixel")
+        return true
+    }
+
+    override suspend fun pushPixels(pixels: List<DefaultAnalyticsPixel>): Boolean {
+        pixels.forEach {
+            pushPixel(it)
         }
         return true
     }

--- a/analytics/src/main/java/com/app/analytics/providers/defaults/DefaultAnalyticsPixel.kt
+++ b/analytics/src/main/java/com/app/analytics/providers/defaults/DefaultAnalyticsPixel.kt
@@ -5,5 +5,6 @@ import androidx.annotation.Keep
 @Keep
 data class DefaultAnalyticsPixel(
     val name: String,
-    val pixel: String
+    val pixel: String,
+    val timeStamp: Long = System.currentTimeMillis()
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,5 @@ org.gradle.daemon=true
 org.gradle.caching=true
 android.useAndroidX=true
 android.enableJetifier=true
+kapt.include.compile.classpath=false
 #android.useAndroidX and android.enableJetifier are specified in each module separately

--- a/network/build.gradle
+++ b/network/build.gradle
@@ -33,7 +33,5 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
     implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
-    //moshi parsing
-    implementation("com.squareup.moshi:moshi-kotlin:1.13.0")
     implementation project(':logger')
 }

--- a/network/src/main/java/com/app/network/RetryPolicy.kt
+++ b/network/src/main/java/com/app/network/RetryPolicy.kt
@@ -4,7 +4,7 @@ import kotlin.math.pow
 
 class RetryPolicy(
     private val maxTries: Int = TOTAL_RETRY,
-    private var remainingTries: Int = TOTAL_RETRY,
+    private var remainingTries: Int = maxTries,
     private val multiplier: RetryMultiplier = RetryMultiplier.LINEAR,
     private val delayInMillis: Long = 500
 ) {

--- a/network/src/main/java/com/app/network/builder/RetrofitBuilder.kt
+++ b/network/src/main/java/com/app/network/builder/RetrofitBuilder.kt
@@ -1,7 +1,6 @@
 package com.app.network.builder
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -16,9 +15,7 @@ class RetrofitBuilder<T>(
 ) {
 
     private val moshi =
-        Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build()
+        Moshi.Builder().build()
     private val okHttpClient by lazy { OkHttpClient.Builder() }
     private val retrofit by lazy {
         val builder = Retrofit.Builder()

--- a/network/src/main/java/com/app/network/builder/RetrofitParams.kt
+++ b/network/src/main/java/com/app/network/builder/RetrofitParams.kt
@@ -5,7 +5,7 @@ import okhttp3.Interceptor
 
 class RetrofitParams {
     var networkInterceptor: Interceptor? = null
-    var apiInterceptors: List<Interceptor>? = null
+    var apiInterceptors: MutableList<Interceptor>? = null
     var retryOnConnectionFailure = false
     var cache: Cache? = null
     var readTimeout: Long = 0

--- a/network/src/main/java/com/app/network/wrapper/HttpCallWrapper.kt
+++ b/network/src/main/java/com/app/network/wrapper/HttpCallWrapper.kt
@@ -21,7 +21,7 @@ suspend fun <T, X> safeApiCall(
         return Either.Success(successTransform(response))
     } catch (e: Exception) {
         retryPolicy.reduceRetries()
-        if (shouldRetryHttpCall(e) && retryPolicy.shouldTry()) {
+        if (retryPolicy.shouldTry() && shouldRetryHttpCall(e)) {
             delay(retryPolicy.getDelay())
             CustomLogger.debug("safeApiCall", "Retry Api call")
             return safeApiCall(apiCall, successTransform, retryPolicy)


### PR DESCRIPTION
- added ability to send pixel from client in analytics SDK
- Refined Analytics SDK config
- Get config response form server
- Added baseUrl field in event class for use case in which each event can have different url destination
- Create MediaNetAdSDK.kt config based on config response from server
- Used Moshi codeGen to avoid slower moshi reflection