### PR TITLE
Duplicate events

### DIFF
--- a/analytics/src/main/java/com/app/analytics/utils/AnalyticsUtil.kt
+++ b/analytics/src/main/java/com/app/analytics/utils/AnalyticsUtil.kt
@@ -2,8 +2,8 @@ package com.app.analytics.utils
 
 import android.net.Uri
 import com.app.analytics.Event
-import com.app.analytics.providers.defaults.DefaultAnalyticsPixel
 import com.app.analytics.providers.cached.db.EventDBEntity
+import com.app.analytics.providers.defaults.DefaultAnalyticsPixel
 
 object AnalyticsUtil {
 


### PR DESCRIPTION
card - https://app.clickup.com/t/8692ze2v8

RCA: Live Data observer will trigger on any change in DB instead if change in 1st row of DB, due to this a race condition occurs as for example

LiveData observer triggers with the event E1 (first event in DB) --> syncing E1 with server But during syncing E2 is inserted in DB --> Observer will triggers again with E1 because E1 is still 1st row (not deleted yet) --> E1 is again syncing to server

Fix: We flag the sync process so , if any event is syncing We close syncing and open again when event successfully deleted from DB  
